### PR TITLE
Copy STT functions from chat screen

### DIFF
--- a/lib/screens/main/chat_speaker_screen.dart
+++ b/lib/screens/main/chat_speaker_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:speech_to_text/speech_recognition_result.dart' as stt;
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:nompangs/services/gemini_service.dart';
+import 'package:nompangs/services/supertone_service.dart';
 import 'chat_setting.dart';
 
 
@@ -15,12 +17,15 @@ class ChatSpeakerScreen extends StatefulWidget {
 
 class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
     with TickerProviderStateMixin {
-  late stt.SpeechToText _speech;
-  bool _speechInitialized = false;
+  final stt.SpeechToText _speech = stt.SpeechToText();
   bool _isListening = false;
-  bool _manualStop = false;
+
+  late SupertoneService _supertoneService;
   late GeminiService _geminiService;
   bool _isProcessing = false;
+
+  bool _showLockButton = false;
+  Timer? _lockTimer;
 
   /// 마지막으로 전달받은 sound level (0.0 ~ 1.0)
   double _lastSoundLevel = 0.0;
@@ -32,7 +37,7 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
   @override
   void initState() {
     super.initState();
-
+    _supertoneService = SupertoneService();
     _geminiService = GeminiService();
     _initSpeech();
     _initEqualizerControllers();
@@ -42,9 +47,9 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
   void dispose() {
     // STT 중지
     if (_isListening) {
-      _manualStop = true;
       _speech.stop();
     }
+    _lockTimer?.cancel();
     // Equalizer AnimationController 해제
     for (var controller in _controllers) {
       controller.dispose();
@@ -54,31 +59,24 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
 
   /// speech_to_text 초기화
   Future<void> _initSpeech() async {
-    _speech = stt.SpeechToText();
-
     if (!await Permission.microphone.request().isGranted) {
       debugPrint('마이크 권한이 거부되었습니다.');
       return;
     }
-
-    setState(() {
-      _speechInitialized = true;
-    });
 
     await _startListening();
   }
 
   /// STT 듣기 시작
   Future<void> _startListening() async {
-    if (!_speechInitialized || _isListening) return;
+    if (_isListening) return;
 
-    _manualStop = false;
+    _cancelLockTimer();
 
     bool available = await _speech.initialize(
-        onStatus: _onSpeechStatus,
-        onError: (errorNotification) {
-          debugPrint('STT initialize error: ' + errorNotification.toString());
-        },
+      onError: (errorNotification) {
+        debugPrint('STT initialize error: ' + errorNotification.toString());
+      },
     );
 
     if (!available) {
@@ -88,17 +86,14 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
 
     _speech.listen(
       onResult: _onSpeechResult,
-      listenFor: const Duration(seconds: 300),
-      // 사용자가 말을 멈춘 뒤 2초가 지나면 자동 중단
-      //pauseFor: const Duration(seconds: 5),
-      partialResults: false,
+      listenFor: const Duration(seconds: 10),
+      pauseFor: const Duration(seconds: 3),
+      partialResults: true,
       localeId: 'ko_KR',
       onSoundLevelChange: (level) {
-        // sound level(0.0~1.0)이 변경될 때마다 업데이트
         _processSoundLevel(level);
       },
       cancelOnError: true,
-      listenMode: stt.ListenMode.dictation,
     );
 
     setState(() {
@@ -109,30 +104,25 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
   /// STT 듣기 중단
   void _stopListening() {
     if (!_isListening) return;
-    _manualStop = true;
     _speech.stop();
     setState(() {
       _isListening = false;
       _lastSoundLevel = 0.0;
     });
-  }
-
-  void _onSpeechStatus(String status) {
-    if (status == 'notListening' && mounted) {
-      setState(() => _isListening = false);
-      if (!_manualStop) {
-        _startListening();
-      }
-    }
+    _cancelLockTimer();
   }
 
   void _onSpeechResult(stt.SpeechRecognitionResult result) {
     final recognized = result.recognizedWords;
     if (recognized.isNotEmpty) {
       debugPrint('\u{1F3A4} 인식된 음성: ' + recognized);
+      if (!result.finalResult) {
+        _startLockTimer();
+      }
     }
     if (result.finalResult && recognized.isNotEmpty) {
       _sendToGemini(recognized);
+      _cancelLockTimer();
     }
   }
 
@@ -143,6 +133,13 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
     setState(() {
       _lastSoundLevel = amplified;
     });
+
+    // 일정 수준 이상의 사운드가 지속되면 잠금 타이머 시작
+    if (amplified > 0.3) {
+      _startLockTimer();
+    } else if (amplified < 0.1) {
+      _cancelLockTimer();
+    }
   }
 
   Future<void> _sendToGemini(String text) async {
@@ -153,6 +150,16 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
       final reply = response['response'] ?? '';
       if (reply.isNotEmpty) {
         debugPrint('\u{1F48E} Gemini 응답: ' + reply);
+        try {
+          await _supertoneService.speak(reply);
+        } catch (e) {
+          debugPrint('TTS 오류: ' + e.toString());
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('음성 재생 중 오류가 발생했습니다.')),
+            );
+          }
+        }
       }
     } catch (e) {
       debugPrint('Gemini 통신 오류: ' + e.toString());
@@ -160,6 +167,27 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
       if (mounted) {
         setState(() => _isProcessing = false);
       }
+    }
+  }
+
+  void _startLockTimer() {
+    // 타이머가 이미 실행 중이라면 재시작하여
+    // 마지막 발화 시점부터 5초를 측정한다.
+    _lockTimer?.cancel();
+    _lockTimer = Timer(const Duration(seconds: 5), () {
+      if (mounted) {
+        setState(() => _showLockButton = true);
+      }
+    });
+  }
+
+  void _cancelLockTimer() {
+    if (_lockTimer != null) {
+      _lockTimer!.cancel();
+      _lockTimer = null;
+    }
+    if (_showLockButton) {
+      setState(() => _showLockButton = false);
     }
   }
 
@@ -246,28 +274,30 @@ class _ChatSpeakerScreenState extends State<ChatSpeakerScreen>
 
                     const SizedBox(height: 48),
 
-                    // ③ 잠금 버튼 (빨간 원 + 자물쇠 아이콘)
-                    GestureDetector(
-                      onTap: () {
-                        if (_isListening) _stopListening();
-                        Navigator.of(context).maybePop();
-                      },
-                      child: Container(
-                        width: 72,
-                        height: 72,
-                        decoration: BoxDecoration(
-                          color: const Color(0xFFE64545),
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Center(
-                          child: Icon(
-                            Icons.lock,
-                            color: Colors.white,
-                            size: 32,
-                          ),
-                        ),
-                      ),
-                    ),
+                    // ③ 잠금 버튼 (5초간 발화 지속 시 표시)
+                    _showLockButton
+                        ? GestureDetector(
+                            onTap: () {
+                              if (_isListening) _stopListening();
+                              Navigator.of(context).maybePop();
+                            },
+                            child: Container(
+                              width: 72,
+                              height: 72,
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFE64545),
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Center(
+                                child: Icon(
+                                  Icons.lock,
+                                  color: Colors.white,
+                                  size: 32,
+                                ),
+                              ),
+                            ),
+                          )
+                        : const SizedBox(height: 72),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- reuse ChatScreen speech initialization and Supertone TTS in ChatSpeakerScreen
- start voice recognition on screen entry and speak AI replies

## Testing
- `dart format lib/screens/main/chat_speaker_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/main/chat_speaker_screen.dart` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fec74123c833181b20735635ba909